### PR TITLE
Fix appending new messages

### DIFF
--- a/bnw_web/static/dynamic.js
+++ b/bnw_web/static/dynamic.js
@@ -46,7 +46,9 @@ function add_node(html, to, at_top) {
     if (at_top) {
         node.prependTo(to);
         // Remove last message.
-        $(to+">div.outerborder").last().remove();
+        if ($(to+">:visible").length > 19) {
+            $(to).children().slice(-1).remove();
+        }
     } else {
         node.appendTo(to);
     }


### PR DESCRIPTION
Delete last message when appending new only if there are enough messages on the page.

(The age of the commit is half of the year, lol.)
