### PR TITLE
Add markdown formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VENV_DEPS=\
 
 install-deb:
 	sudo apt-get install $(DEBIAN_DEPS)
-	sudo pip install 'git+https://github.com/fiorix/mongo-async-python-driver.git#egg=txmongo'
+	sudo pip install 'git+https://github.com/fiorix/mongo-async-python-driver.git#egg=txmongo' misaka
 
 uninstall-deb:
 	sudo pip uninstall txmongo
@@ -40,7 +40,7 @@ install-venv:
 	# (from python-xapian package) and so we should allow
 	# global site-packages in virtualenv.
 	virtualenv --system-site-packages .venv
-	$(PIP) install twisted tornado PyRSS2Gen PIL
+	$(PIP) install twisted tornado PyRSS2Gen PIL misaka
 	$(PIP) install -e 'git+https://github.com/fiorix/mongo-async-python-driver.git#egg=txmongo'
 
 uninstall-venv:

--- a/bnw_web/rss.py
+++ b/bnw_web/rss.py
@@ -75,7 +75,7 @@ def message_feed(messages, link, title, *args, **kwargs):
         pubDate=datetime.utcfromtimestamp(msg['date']),
         categories=set(msg['tags']) | set(msg['clubs']),
         title='@%s: #%s' % (msg['user'], msg['id']),
-        description=BnwDescription(linkify(msg['text']).replace('\n', '<br/>'))) for msg in messages]
+        description=BnwDescription(linkify(msg['text'], msg.get('format')).replace('\n', '<br/>'))) for msg in messages]
 
     rss_feed = BnwRSSFeed(title=title,
                           link=link,

--- a/bnw_web/site.py
+++ b/bnw_web/site.py
@@ -14,7 +14,6 @@ import json
 import txmongo
 import os
 from widgets import widgets
-from linkify import thumbify
 import uimodules
 import rss
 import base64

--- a/bnw_web/static/basestyle.css
+++ b/bnw_web/static/basestyle.css
@@ -15,6 +15,12 @@
             font-size: 1em;
         }
 
+        /* Inline code */
+        .pw > code {
+            display: inline;
+            padding: 0;
+        }
+
         .bodyshit {
             padding: 1em;
         }

--- a/bnw_web/templates/module-comment.html
+++ b/bnw_web/templates/module-comment.html
@@ -1,7 +1,7 @@
 <div class='outerborder hentry comment_entry' id="{{ comment['id'].split('/')[1] }}">
 <div class='comment'>
     <img class='avatar avatar_ps' alt='avatar' src='/u/{{ comment['user'] }}/avatar/thumb' />
-    {% set linkified, thumbs = thumbify(comment['text']) %}
+    {% set linkified, thumbs = thumbify(comment['text'], comment.get('format')) %}
     {% if thumbs %}<div class="imgpreviews">
         {% for thumb in thumbs %}<a class="imglink" href="{{ thumb[0] }}">
             <img class="imgpreview imgpreview_ps" src="{{ thumb[1] }}"/>

--- a/bnw_web/templates/module-message.html
+++ b/bnw_web/templates/module-message.html
@@ -5,7 +5,7 @@
         {% if msg.get('loltroll') %}
             <pre class='pw entry-title entry-content'>{{ msg.get('loltroll') }}</pre>
         {% else %}
-            {% set linkified, thumbs = thumbify(msg['text']) %}
+            {% set linkified, thumbs = thumbify(msg['text'], msg.get('format')) %}
             {% if thumbs %}<div class="imgpreviews">
                 {% for thumb in thumbs %}<a class="imglink" href="{{ thumb[0] }}">
                     <img class="imgpreview imgpreview_ps" src="{{ thumb[1] }}"/>

--- a/bnw_web/templates/userinfo.html
+++ b/bnw_web/templates/userinfo.html
@@ -47,7 +47,7 @@
         {% if about %}
         <tr>
           <td>О себе:</td>
-          <td class='pw note'>{{ thumbify(about)[0] }}</td>
+          <td class='pw note'>{{ linkify(about) }}</td>
         </tr>
         {% end %}
         <tr><td>Подписки:</td>

--- a/tests/test/test_linkify.py
+++ b/tests/test/test_linkify.py
@@ -1,10 +1,16 @@
 # coding: utf-8
 
 from twisted.trial import unittest
-from bnw_web.linkify import linkify as l
+
+from bnw_web.linkify import linkify
+
+
+def l(text):
+    return linkify(text, format="moinmoin")
 
 
 class LinkifyTest(unittest.TestCase):
+
     def test_simple_formatting(self):
         self.assertEqual(
             l('test //test test// test **test test** test'),

--- a/tests/test/test_markdown.py
+++ b/tests/test/test_markdown.py
@@ -1,0 +1,81 @@
+from twisted.trial import unittest
+
+from bnw_web.linkify import linkify as l
+
+
+class MarkdownTest(unittest.TestCase):
+
+    def test_escaping(self):
+        self.assertEqual(
+            l('Test <html><body><&"\'></body></html>'),
+            'Test &lt;html&gt;&lt;body&gt;&lt;&amp;&quot;&#39;&gt;&lt;/body&gt;&lt;/html&gt;')
+
+    def test_custom_paragraphs(self):
+        self.assertEqual(
+            l('test\n\ntest'),
+            'test\ntest')
+
+    def test_trailing_newlines(self):
+        self.assertEqual(
+            l('Hi\nHi\nBye\n\n\n'),
+            'Hi\nHi\nBye')
+
+    def test_forbidden_header(self):
+        self.assertEqual(
+            l('abc\n#forbidden\ntest'),
+            'abc\n#forbidden\ntest')
+
+    def test_allowed_header(self):
+        self.assertEqual(
+            l('abc\n####allowed\ntest'),
+            'abc\n<h4>allowed</h4>test')
+
+    def test_escaping_in_header(self):
+        self.assertEqual(
+            l('#<bad>&amp'),
+            '#&lt;bad&gt;&amp;amp')
+        self.assertEqual(
+            l('####<bad>&amp'),
+            '<h4>&lt;bad&gt;&amp;amp</h4>')
+
+    def test_autolink(self):
+        self.assertEqual(
+            l('Nyak: http://example.com/ ne nyak'),
+            'Nyak: <a href="http://example.com/">http://example.com/</a> ne nyak')
+
+    def test_forbidden_image(self):
+        self.assertEqual(
+            l('Look at this: ![Cool image](http://example.com/goatse.jpg)'),
+            'Look at this: <a href="http://example.com/goatse.jpg">http://example.com/goatse.jpg</a>')
+
+    def test_escaping_in_links(self):
+        self.assertEqual(
+            l('Bad: <http://nyan.ru/&&&>'),
+            'Bad: <a href="http://nyan.ru/&amp;&amp;&amp;">http://nyan.ru/&amp;&amp;&amp;</a>')
+        self.assertEqual(
+            l('Look at this: ![Cool image](http://example.com/<bad>&amp;)'),
+            'Look at this: <a href="http://example.com/&lt;bad&gt;&amp;amp;">http://example.com/&lt;bad&gt;&amp;amp;</a>')
+
+    def test_inline_code(self):
+        self.assertEqual(
+            l('`simple code`'),
+            '<code>simple code</code>')
+
+    def test_block_code(self):
+        self.assertEqual(
+            l('```\ncode block\nline2\n```'),
+            '<pre><code>code block\nline2</code></pre>')
+        self.assertEqual(
+            l('```javascript\na = 1\nb = a + 1\n```'),
+            '<pre><code class="language-javascript">a = 1\nb = a + 1</code></pre>')
+
+    def test_escaping_in_code(self):
+        self.assertEqual(
+            l('some\ncode: `simple <&bad code>` <- code'),
+            'some\ncode: <code>simple &lt;&amp;bad code&gt;</code> &lt;- code')
+        self.assertEqual(
+            l('code:\n\n```\n<bad code &&&>&">\n```'),
+            'code:\n<pre><code>&lt;bad code &amp;&amp;&amp;&gt;&amp;&quot;&gt;</code></pre>')
+        self.assertEqual(
+            l('```<bad&language>\n<bad code>\n```'),
+            '<pre><code class="language-&lt;bad&amp;language&gt;">&lt;bad code&gt;</code></pre>')


### PR DESCRIPTION
Deploying steps:
- Install extra dep: `pip install misaka`
- Explicitly send old format for all comments and messages (in mongo shell):
  
  ```
  > db.messages.update({}, {$set: {format:"moinmoin"}}, {multi: true})
  > db.comments.update({}, {$set: {format:"moinmoin"}}, {multi: true})
  ```
