### PR TITLE
Don't interpret plus signs as spaces in URLs

### DIFF
--- a/bnw/web/site.py
+++ b/bnw/web/site.py
@@ -320,10 +320,10 @@ class MainHandler(BnwWebHandler, AuthMixin):
         page = get_page(self)
         qdict = {}
         if tag:
-            tag = tornado.escape.url_unescape(tag)
+            tag = tornado.escape.url_unescape(tag, plus=False)
             qdict['tags'] = tag
         if club:
-            club = tornado.escape.url_unescape(club)
+            club = tornado.escape.url_unescape(club, plus=False)
             qdict['clubs'] = club
         if user:
             bl = []


### PR DESCRIPTION
URL unescaping function interpret plus signs in URLs as spaces so there is no way to see some tag pages (e.g. [*c++](https://bnw.im/t/c++))

`plus` argument set to `False` will change this behavior, see [docs here](http://tornado.readthedocs.org/en/latest/escape.html#tornado.escape.url_unescape), but this argument was introduced in tornado 3.1
So **if you have tornado>=3.1 installed** please merge this PR.
// _or make your own unescape function_

Original bug report by @​fix: https://bnw.im/p/LK6ITX
