### PR TITLE
Fix web interface

### DIFF
--- a/bnw/formatting/linkshit_format.py
+++ b/bnw/formatting/linkshit_format.py
@@ -10,7 +10,9 @@ from libthumbor import CryptoURL
 from bnw.core.base import config
 from bnw.handlers.base import USER_RE
 
-_USER_RE = re.compile(ur"""(?:(?<=[\s\W])|^)%s""" % USER_RE)
+# we strip first two characters of USER_RE, i.e. "@?", because we *require* "at
+# sign" to be present
+_USER_RE = re.compile(ur"""(?:(?<=[\s\W])|^)@%s""" % USER_RE[2:])
 
 bnw_types = (
     ('msg', _MSG_RE, lambda m: (m.group(1),)),


### PR DESCRIPTION
4c7f4c4189e65e6d254c383ef0dceebe56ca0271 broke things: anything that
matched [0-9A-Za-z]+ was considered to be a username and thus
highlighted.

I apologize for the havoc that bug wreaked.
