### PR TITLE
Don't treat plus signs as spaces in urls. Fix #103

### DIFF
--- a/bnw/web/site.py
+++ b/bnw/web/site.py
@@ -208,7 +208,7 @@ class UserHandler(BnwWebHandler, AuthMixin):
             qdict = {'user': username}
 
         if tag:
-            tag = tornado.escape.url_unescape(tag)
+            tag = tornado.escape.url_unescape(tag, plus=False)
             qdict['tags'] = tag
         messages = list((yield objs.Message.find_sort(qdict, sort=f, limit=20, skip=20 * page)))
         hasmes = yield is_hasmes(qdict, page)
@@ -246,7 +246,7 @@ class UserRecoHandler(BnwWebHandler, AuthMixin):
         page = get_page(self)
         qdict = {'recommendations': username}
         if tag:
-            tag = tornado.escape.url_unescape(tag)
+            tag = tornado.escape.url_unescape(tag, plus=False)
             qdict['tags'] = tag
         messages = list((yield objs.Message.find_sort(qdict, sort=f, limit=20, skip=20 * page)))
         hasmes = yield is_hasmes(qdict, page)


### PR DESCRIPTION
Apply fix from #69 to other pages as well