### PR TITLE
Add asterisks before tags in RSS items' titles

### DIFF
--- a/bnw/web/rss.py
+++ b/bnw/web/rss.py
@@ -69,12 +69,13 @@ class AtomSelf(object):
 
 
 def message_feed(messages, link, title, *args, **kwargs):
+    tags = ' '.join("*" + t for t in msg['tags']))
     rss_items = [PyRSS2Gen.RSSItem(  # author=msg['user'],
         link=widgets.post_url(msg['id']),
         guid=widgets.post_url(msg['id']),
         pubDate=datetime.utcfromtimestamp(msg['date']),
         categories=set(msg['tags']) | set(msg['clubs']),
-        title='@%s: #%s %s' % (msg['user'], msg['id'], ', '.join(msg['tags'])),
+        title='@%s: #%s %s' % (msg['user'], msg['id'], tags),
         description=BnwDescription(linkify(msg['text'], msg.get('format')).replace('\n', '<br/>'))) for msg in messages]
 
     rss_feed = BnwRSSFeed(title=title,


### PR DESCRIPTION
Sorry for loads of one-line patches, and thanks for your patience!