### PR TITLE
Highlight target comment

### DIFF
--- a/bnw/web/static/basestyle.css
+++ b/bnw/web/static/basestyle.css
@@ -119,6 +119,12 @@
 
             border: thin solid black;
         }
+        .comments div:target {
+	    background-color: #ffff00;
+        }
+        .comments div:target .comment {
+	    background-color: #e5e5e5;
+        }
         .comment {
             color: #000;
 


### PR DESCRIPTION
In case when someone posted direct link to bnw comment it's hard to figure out which comment you should actually look at. With this change it will be highlighted automatically:

![screenshot from 2018-09-19 13-15-29](https://user-images.githubusercontent.com/3204785/45747350-42bc4980-bc0e-11e8-986c-c4e714d0b78e.png)
